### PR TITLE
use 0.6 instead of release on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
release is 0.5 now, and 0.4 is still supported here according to REQUIRE